### PR TITLE
feat: explicitly require `openssh-client`

### DIFF
--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install Package
         uses: ConorMacBride/install-package@main
         with:
-          apt: git unzip nodejs python3-pip python3-venv rsync
+          apt: git unzip nodejs python3-pip python3-venv rsync openssh-client
 
       # If testing upgrade, checkout previous release, otherwise checkout current branch
       - name: Checkout ${{ inputs.upgrade && 'previous release' || 'current' }} config


### PR DESCRIPTION
Multinode workflows are failing due to `ssh-keygen: command not found` it appears that this maybe due to `openssh-client` being a suggested and never being installed. Possibly due to the `git` being already latest version and `openssh-client` being installed alongside it.

Fails `git` already installed `openssh-client` skipped as suggested package. https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/11173185437/job/31060852769#step:4:39

Works `git` doesn't show as latest version and `openssh-client` is an additional package to be installed. https://github.com/stackhpc/stackhpc-kayobe-config/actions/runs/11155063059/job/31005381381#step:4:67