### PR TITLE
Print final log lines to gh output

### DIFF
--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -363,6 +363,11 @@ jobs:
         working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
         if: ${{ always() && steps.config_ach.outcome == 'success' }}
 
+      - name: Print final lines of tmux log
+        run: |
+          tail -n 250 ${{ github.workspace }}/logs/tmux.kayobe:0.log
+        if: ${{ failure() && steps.config_ach.outcome == 'success' }}
+
       # GitHub Actions does not accept filenames with certain characters, and
       # fails the upload-artifact action if any exist.  The tmux log file
       # contains a colon, as do previous Tempest results directories.


### PR DESCRIPTION
Currently, when a multinode workflow fails, the only way to see what happened is to download the logs artifact and read the tmux logs. These logs are often quite large

This change prints the final 250 lines of the tmux log to the GitHub output when the workflow fails, making it easier to quickly see what went wrong