### PR TITLE
Multinodes now tagged for cleanup by CI

### DIFF
--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -226,7 +226,7 @@ jobs:
           infra_vm_flavor    = "${{ env.MULTINODE_INFRA_VM_FLAVOR }}"
           infra_vm_disk_size = 100
 
-          compute_tags = ["gh-actions-multinode"]
+          instance_tags = ["gh-actions-multinode"]
           EOF
 
           if [[ "${{ inputs.ssh_key }}" != "" ]]; then

--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -225,6 +225,8 @@ jobs:
           deploy_wazuh       = false
           infra_vm_flavor    = "${{ env.MULTINODE_INFRA_VM_FLAVOR }}"
           infra_vm_disk_size = 100
+
+          compute_tags = ["gh-actions-multinode"]
           EOF
 
           if [[ "${{ inputs.ssh_key }}" != "" ]]; then


### PR DESCRIPTION
Added `gh-actions-multinode` tag to all compute instances to allow them to be cleaned up by https://github.com/stackhpc/stackhpc-kayobe-config/pull/1295