### PR TITLE
Revert "Add input to choose secret store for CA"

### DIFF
--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -39,10 +39,6 @@ on:
         description: Neutron ML2 plugin
         type: string
         default: ovn
-      secret_store:
-        description: Secret store to use as Certificate Authority
-        type: string
-        default: openbao
       stackhpc_kayobe_config_version:
         description: stackhpc-kayobe-config version
         type: string
@@ -274,14 +270,12 @@ jobs:
           ssh_key_path: ${{ github.workspace }}/terraform-kayobe-multinode/id_rsa
           vxlan_vni: ${{ steps.vxlan_vni.outputs.vxlan_vni }}
           vault_password_path: ${{ github.workspace }}/terraform-kayobe-multinode/vault-pw
-          certificate_authority: ${{ inputs.secret_store }}
           kayobe_config_custom:
             - path: zz-multinode.yml
               block: |
                 os_distribution: ${{ env.OS_DISTRIBUTION }}
                 os_release: "${{ env.OS_RELEASE }}"
                 kolla_enable_ovn: ${{ env.ENABLE_OVN }}
-                stackhpc_enable_openbao: ${{ env.ENABLE_OPENBAO }}
           EOF
 
           if [[ "${{ env.SSH_KEY }}" != "" ]]; then
@@ -293,7 +287,6 @@ jobs:
         working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
         env:
           ENABLE_OVN: ${{ inputs.neutron_plugin == 'ovn' }}
-          ENABLE_OPENBAO: ${{ inputs.secret_store == 'openbao' }}
           OS_DISTRIBUTION: ${{ inputs.os_distribution }}
           OS_RELEASE: ${{ inputs.os_release }}
           SSH_KEY: ${{ inputs.ssh_key }}


### PR DESCRIPTION
Reverts stackhpc/stackhpc-openstack-gh-workflows#13

As we are making setting this possible with SKC varaibles [1], we don't need this change.

[1] https://github.com/stackhpc/stackhpc-kayobe-config/pull/1740