### PR TITLE
Checkout to previous terraform-kayobe-multinode when major upgrading

### DIFF
--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -346,6 +346,12 @@ jobs:
         working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
         if: inputs.upgrade == 'major'
 
+      - name: Stash changes before checking out to current terraform-kayobe-multinode
+        run: |
+          git stash
+        working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
+        if: inputs.upgrade == 'major'
+
       - name: Checkout current terraform-kayobe-multinode
         uses: actions/checkout@v4
         with:
@@ -354,6 +360,26 @@ jobs:
           ref: ${{ inputs.terraform_kayobe_multinode_version }}
           path: terraform-kayobe-multinode
         if: inputs.upgrade == 'major'
+
+      - name: Pop stashed terraform-kayobe-multinode changes
+        id: pop-tkm
+        run: |
+          git stash pop
+        working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
+        if: inputs.upgrade == 'major'
+
+      - name: Check terraform-kayobe-multinode git diff on pop failure
+        id: git-diff-tkm
+        run: |
+          echo "GIT_DIFF_TKM=$(git diff)" >> $GITHUB_OUTPUT
+        working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
+        if: steps.pop-tkm.outcome == 'failure'
+
+      - name: Display terraform-kayobe-multinode git diff on pop failure
+        run: |
+          echo "${{ steps.git-diff-tkm.outputs.GIT_DIFF_TKM }}"
+        working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
+        if: steps.pop-tkm.outcome == 'failure'
 
       - name: Upgrade Ansible control host
         run: |

--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -50,6 +50,9 @@ on:
         description: terraform-kayobe-multinode version
         type: string
         default: main
+      terraform_kayobe_multinode_previous_version:
+        description: terraform-kayobe-multinode previous version
+        type: string
       upgrade:
         # Supported values: 'none', 'minor', 'major'
         description: Whether to perform an upgrade
@@ -95,11 +98,17 @@ jobs:
       KAYOBE_ENVIRONMENT: ci-multinode
       KAYOBE_VAULT_PASSWORD: ${{ secrets.KAYOBE_VAULT_PASSWORD_CI_MULTINODE }}
     steps:
-      - name: Fail if previous version is not defined
+      - name: Fail if stackhpc-kayobe-config previous version is not defined
         run: |
           echo "StackHPC Kayobe Configuration previous version must be defined for upgrades"
           exit 1
         if: ${{ (inputs.upgrade != 'none') && inputs.stackhpc_kayobe_config_previous_version == '' }}
+
+      - name: Fail if terraform-kayobe-multinode previous version is not defined
+        run: |
+          echo "StackHPC Kayobe Configuration previous version must be defined for upgrades"
+          exit 1
+        if: ${{ (inputs.upgrade == 'major') && inputs.terraform_kayobe_multinode_previous_version == '' }}
 
       - name: Fail if no SSH key is provided for break_on
         run: |
@@ -119,11 +128,11 @@ jobs:
           repository: stackhpc/stackhpc-kayobe-config
           ref: ${{ (inputs.upgrade != 'none') && inputs.stackhpc_kayobe_config_previous_version || inputs.stackhpc_kayobe_config_version }}
 
-      - name: Checkout terraform-kayobe-multinode
+      - name: Checkout ${{ (inputs.upgrade == 'major') && 'previous release' || 'current' }} terraform-kayobe-multinode
         uses: actions/checkout@v4
         with:
           repository: stackhpc/terraform-kayobe-multinode
-          ref: ${{ inputs.terraform_kayobe_multinode_version }}
+          ref: ${{ (inputs.upgrade == 'major') && inputs.terraform_kayobe_multinode_previous_version || inputs.terraform_kayobe_multinode_version }}
           path: terraform-kayobe-multinode
 
       - name: Make sure dockerd is running and test Docker
@@ -335,6 +344,14 @@ jobs:
           source venv/bin/activate &&
           ansible-playbook -v -i ansible/inventory.yml ansible/deploy-openstack.yml -e multinode_command=upgrade_prerequisites
         working-directory: ${{ github.workspace }}/terraform-kayobe-multinode
+        if: inputs.upgrade == 'major'
+
+      - name: Checkout current terraform-kayobe-multinode
+        uses: actions/checkout@v4
+        with:
+          repository: stackhpc/terraform-kayobe-multinode
+          ref: ${{ inputs.terraform_kayobe_multinode_version }}
+          path: terraform-kayobe-multinode
         if: inputs.upgrade == 'major'
 
       - name: Upgrade Ansible control host

--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -349,6 +349,7 @@ jobs:
       - name: Checkout current terraform-kayobe-multinode
         uses: actions/checkout@v4
         with:
+          clean: false
           repository: stackhpc/terraform-kayobe-multinode
           ref: ${{ inputs.terraform_kayobe_multinode_version }}
           path: terraform-kayobe-multinode
@@ -440,6 +441,7 @@ jobs:
             neutron_plugin: ${{ inputs.neutron_plugin }}\n
             stackhpc_kayobe_config_version: ${{ inputs.stackhpc_kayobe_config_version }}\n
             stackhpc_kayobe_config_previous_version: ${{ inputs.stackhpc_kayobe_config_previous_version }}\n
+            terraform_kayobe_multinode_previous_version: ${{ inputs.terraform_kayobe_multinode_previous_version }}\n
             terraform_kayobe_multinode_version: ${{ inputs.terraform_kayobe_multinode_version }}\n
             upgrade: ${{ inputs.upgrade }}\n
           MESSAGE: "Multinode workflow failed :sob:"


### PR DESCRIPTION
Openstack with stackhpc-kayobe-config requires
different version of terraform-kayobe-multinode when upgrading from Caracal to Epoxy release.