### PR TITLE
Limit ansible to 13  to avoid breaking change in ansible-core 2.21

### DIFF
--- a/.github/workflows/multinode.yml
+++ b/.github/workflows/multinode.yml
@@ -181,7 +181,7 @@ jobs:
           python3 -m venv venv &&
           source venv/bin/activate &&
           pip install -U pip &&
-          pip install ansible &&
+          pip install -r ansible/requirements.txt &&
           mkdir -p ansible/{collections,roles} &&
           ansible-galaxy role install -r ansible/requirements.yml -p ansible/roles &&
           ansible-galaxy collection install -r ansible/requirements.yml -p ansible/collections


### PR DESCRIPTION
inventory plugins still use the 'required' parameter, removed from get_bin_path()